### PR TITLE
Address Double Satisfaction Vulnerability of Multi UTxO Indexers

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ as possible, the provided higher-order function takes 3 validation logics:
 2. A function that validates the input UTxO against a corresponding output
    UTxO. Note that this is executed for each associated output.
 3. A function that validates the collective outputs. This also runs only once.
-   An example use-case could be checking for the number of outputs.
+   The number of outputs is also available for this function (its second
+   argument).
 
 #### Multi UTxO Indexer
 
@@ -131,6 +132,10 @@ Subsequently, spend redeemers are irrelevant here. The redeemer of the
 withdrawal endpoint is expected to be a properly sorted list of pairs of
 indices (for the one-to-one case), or a list of one-to-many mappings of
 indices.
+
+It's worth emphasizing that it is necessary for this design to be a
+multi-validator as the staking logic filters inputs that are coming from a
+script address which its validator hash is identical to its own.
 
 The distinction between one-to-one and one-to-many variants here is very
 similar to the singular case, so please refer to [its section above](#singular-utxo-indexer) for

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ The distinction between one-to-one and one-to-many variants here is very
 similar to the singular case, so please refer to [its section above](#singular-utxo-indexer) for
 more details.
 
+The primary difference is that here, input indices should be provided for the
+_filtered_ list of inputs, i.e. only script inputs, unlike the singular variant
+where the index applies to all the inputs of the transaction. This slight
+inconvenience is for preventing extra overhead on-chain.
+
 ### Transaction Level Validator Minting Policy
 
 Very similar to the [stake validator](#stake-validator), this design pattern

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The exposed `spend` function from `merkelized_validator` expects 3 arguments:
 This function expects to find the given stake validator in the `redeemers` list,
 such that its redeemer is of type `WithdrawRedeemer` (which carries the list of
 input arguments and the list of expected outputs), makes sure provided inputs
-match the one's given to the validator through its redeemer, and returns the
+match the ones given to the validator through its redeemer, and returns the
 outputs (which are carried inside the withdrawal redeemer) so that you can
 safely use them.
 

--- a/lib/aiken-design-patterns/multi-utxo-indexer-one-to-many.ak
+++ b/lib/aiken-design-patterns/multi-utxo-indexer-one-to-many.ak
@@ -1,30 +1,55 @@
 use aiken/list
 use aiken/transaction.{Input, Output, ScriptContext, Transaction}
+use aiken/transaction/credential.{Address, ScriptCredential}
 use aiken_design_patterns/stake_validator as stake_validator
 
 pub fn withdraw(
   input_validator: fn(Input) -> Bool,
   input_output_validator: fn(Output, Output) -> Bool,
-  collective_output_validator: fn(List<Output>) -> Bool,
+  collective_output_validator: fn(List<Output>, Int) -> Bool,
   redeemer: List<(Int, List<Int>)>,
   ctx: ScriptContext,
 ) -> Bool {
   stake_validator.withdraw(
-    fn(indicesData, _own_validator, tx) {
+    fn(indicesData, own_validator, tx) {
       let Transaction { inputs, outputs, .. } = tx
+      let (script_inputs, script_input_count) =
+        list.foldr(
+          inputs,
+          ([], 0),
+          fn(i, acc_tuple) {
+            expect Input {
+              output: Output {
+                address: Address {
+                  payment_credential: ScriptCredential(script),
+                  ..
+                },
+                ..
+              },
+              ..
+            } = i
+            if script == own_validator {
+              let (acc, count) = acc_tuple
+              ([i, ..acc], count + 1)
+            } else {
+              acc_tuple
+            }
+          },
+        )
       expect indices: List<(Int, List<Int>)> = indicesData
       // Folding the outer list of indices from left.
-      let (_, _) =
+      let (_, _, input_index_count) =
         list.foldl(
           indices,
-          (-1, -1),
-          fn(curr, prev_ixs) {
-            let (prev_in_ix, latest_out_ix) = prev_ixs
+          (-1, -1, 0),
+          fn(curr, prev_ixs_and_count) {
+            let (prev_in_ix, latest_out_ix, input_count_so_far) =
+              prev_ixs_and_count
 
             let (curr_in_ix, out_ixs) = curr
 
             expect Some(Input { output: in_utxo, .. } as input) =
-              inputs |> list.at(curr_in_ix)
+              script_inputs |> list.at(curr_in_ix)
 
             expect input_validator(input)?
 
@@ -33,27 +58,31 @@ pub fn withdraw(
               // found UTxOs are going to be added to the head of the
               // accumulator while the folding occurs from left, in order to
               // provide a more intuitive interface, the UTxOs list need to be
-              // reversed before `validation_logic` applies to it.
-              let (new_latest_out_ix, out_utxos_reversed) =
+              // reversed before `validation_logic` is applied to it.
+              let (new_latest_out_ix, out_utxos_reversed, output_count) =
                 list.foldl(
                   out_ixs,
-                  (latest_out_ix, []),
-                  fn(curr_out_ix, acc_tuple) {
-                    let (prev_out_ix, utxos_so_far) = acc_tuple
+                  (latest_out_ix, [], 0),
+                  fn(curr_out_ix, acc_triplet) {
+                    let (prev_out_ix, utxos_so_far, count) = acc_triplet
                     if curr_out_ix > prev_out_ix {
                       expect Some(out_utxo) = outputs |> list.at(curr_out_ix)
                       expect input_output_validator(in_utxo, out_utxo)?
-                      (curr_out_ix, utxos_so_far |> list.push(out_utxo))
+                      (
+                        curr_out_ix,
+                        utxos_so_far |> list.push(out_utxo),
+                        count + 1,
+                      )
                     } else {
                       fail @"All output indices must be in ascending order"
                     }
                   },
                 )
               let out_utxos = list.reverse(out_utxos_reversed)
-              if collective_output_validator(out_utxos) {
+              if collective_output_validator(out_utxos, output_count) {
                 // Passing the current input index, and the biggest output
                 // index found with the inner fold.
-                (curr_in_ix, new_latest_out_ix)
+                (curr_in_ix, new_latest_out_ix, input_count_so_far + 1)
               } else {
                 fail @"Collection of outputs are not valid"
               }
@@ -62,7 +91,7 @@ pub fn withdraw(
             }
           },
         )
-      True
+      (script_input_count == input_index_count)?
     },
     redeemer,
     ctx,

--- a/lib/aiken-design-patterns/multi-utxo-indexer.ak
+++ b/lib/aiken-design-patterns/multi-utxo-indexer.ak
@@ -1,5 +1,6 @@
 use aiken/list
 use aiken/transaction.{Input, Output, ScriptContext, Transaction}
+use aiken/transaction/credential.{Address, ScriptCredential}
 use aiken_design_patterns/stake_validator as stake_validator
 
 pub fn withdraw(
@@ -8,24 +9,46 @@ pub fn withdraw(
   ctx: ScriptContext,
 ) -> Bool {
   stake_validator.withdraw(
-    fn(indicesData, _own_validator, tx) {
+    fn(indicesData, own_validator, tx) {
       let Transaction { inputs, outputs, .. } = tx
+      let (script_inputs, script_input_count) =
+        list.foldr(
+          inputs,
+          ([], 0),
+          fn(i, acc_tuple) {
+            expect Input {
+              output: Output {
+                address: Address {
+                  payment_credential: ScriptCredential(script),
+                  ..
+                },
+                ..
+              } as o,
+              ..
+            } = i
+            if script == own_validator {
+              let (acc, count) = acc_tuple
+              ([o, ..acc], count + 1)
+            } else {
+              acc_tuple
+            }
+          },
+        )
       expect indices: List<(Int, Int)> = indicesData
       when indices is {
-        [head, ..tail] -> {
-          let (_, _) =
+        [(ix0, ox0), ..tail] -> {
+          let (_, _, input_index_count) =
             list.foldl(
               tail,
-              head,
-              fn(curr, prev) {
-                let (in0, out0) = prev
+              (ix0, ox0, 0),
+              fn(curr, acc) {
+                let (in0, out0, count) = acc
                 let (in1, out1) = curr
                 if in1 > in0 && out1 > out0 {
-                  expect Some(Input { output: in_utxo, .. }) =
-                    inputs |> list.at(in1)
+                  expect Some(in_utxo) = script_inputs |> list.at(in1)
                   expect Some(out_utxo) = outputs |> list.at(out1)
                   if validation_logic(in_utxo, out_utxo) {
-                    curr
+                    (in1, out1, count + 1)
                   } else {
                     fail @"Validation failed"
                   }
@@ -36,7 +59,7 @@ pub fn withdraw(
                 }
               },
             )
-          True
+          (script_input_count == input_index_count)?
         }
         _ -> fail @"No indices provided"
       }

--- a/lib/aiken-design-patterns/singular-utxo-indexer-one-to-many.ak
+++ b/lib/aiken-design-patterns/singular-utxo-indexer-one-to-many.ak
@@ -4,7 +4,7 @@ use aiken/transaction.{Input, Output, ScriptContext, Spend, Transaction}
 pub fn spend(
   input_validator: fn(Input) -> Bool,
   input_output_validator: fn(Output, Output) -> Bool,
-  collective_output_validator: fn(List<Output>) -> Bool,
+  collective_output_validator: fn(List<Output>, Int) -> Bool,
   redeemer: (Int, List<Int>),
   ctx: ScriptContext,
 ) -> Bool {
@@ -19,10 +19,11 @@ pub fn spend(
 
   expect input_validator(input)?
 
-  let fold_res =
+  let output_count = list.length(outputs)
+  let (_, out_utxos) =
     list.foldr(
       out_ixs,
-      (list.length(outputs), []),
+      (output_count, []),
       fn(curr_ix, acc_tuple) {
         let (prev_ix, acc) = acc_tuple
         // Folding from right and expecting ascending order from head to tail
@@ -37,10 +38,8 @@ pub fn spend(
       },
     )
 
-  let (_, out_utxos) = fold_res
-
   // Indicated input must match the spending one.
   expect (own_ref == in_ref)?
 
-  collective_output_validator(out_utxos)
+  collective_output_validator(out_utxos, output_count)
 }

--- a/validators/multi-utxo-indexer-one-to-many-example.ak
+++ b/validators/multi-utxo-indexer-one-to-many-example.ak
@@ -12,7 +12,7 @@ validator(_state_token_symbol: PolicyId, _state_token_name: AssetName) {
     multi_utxo_indexer.withdraw(
       fn(_input) { True },
       fn(_in_utxo, _out_utxo) { True },
-      fn(_out_utxos) { True },
+      fn(_out_utxos, _output_count) { True },
       redeemer,
       ctx,
     )

--- a/validators/singular-utxo-indexer-one-to-many-example.ak
+++ b/validators/singular-utxo-indexer-one-to-many-example.ak
@@ -7,7 +7,7 @@ validator(_state_token_symbol: PolicyId, _state_token_name: AssetName) {
     singular_utxo_indexer.spend(
       fn(_input) { True },
       fn(_in_utxo, _out_utxo) { True },
-      fn(_out_utxos) { True },
+      fn(_out_utxos, _output_count) { True },
       redeemer,
       ctx,
     )


### PR DESCRIPTION
Thanks to @solidsnakedev for spotting this error, this PR adds extra validations to make sure the same number of script inputs are being spent as there are input indices provided in the redeemer.

Additionally, the one-to-many variants' `collective_output_validator` functions are now provided with the total count of outputs (aside from the list of outputs). This has little extra cost, while if users required this value, it'd cost them one additional traversal to attain.