### PR TITLE
fix:(utils.ak) formatting errors in resolve_output_reference

### DIFF
--- a/lib/aiken-design-patterns/multi-utxo-indexer-one-to-many.ak
+++ b/lib/aiken-design-patterns/multi-utxo-indexer-one-to-many.ak
@@ -19,14 +19,13 @@ pub fn withdraw(
           ([], 0),
           fn(i, acc_tuple) {
             when i.output.address.payment_credential is {
-              ScriptCredential(script) -> {
+              ScriptCredential(script) ->
                 if script == own_validator {
                   let (acc, count) = acc_tuple
                   ([i, ..acc], count + 1)
                 } else {
                   acc_tuple
                 }
-              }
               _ -> acc_tuple
             }
           },

--- a/lib/aiken-design-patterns/multi-utxo-indexer.ak
+++ b/lib/aiken-design-patterns/multi-utxo-indexer.ak
@@ -16,19 +16,15 @@ pub fn withdraw(
           inputs,
           ([], 0),
           fn(i, acc_tuple) {
-            let Input {
-              output,
-              ..
-            } = i
+            let Input { output, .. } = i
             when output.address.payment_credential is {
-              ScriptCredential(script) -> {
+              ScriptCredential(script) ->
                 if script == own_validator {
                   let (acc, count) = acc_tuple
                   ([output, ..acc], count + 1)
                 } else {
                   acc_tuple
                 }
-              }
               _ -> acc_tuple
             }
           },

--- a/lib/aiken-design-patterns/utils.ak
+++ b/lib/aiken-design-patterns/utils.ak
@@ -1,5 +1,6 @@
+use aiken/builtin
 use aiken/list.{foldl}
-use aiken/transaction.{Output}
+use aiken/transaction.{Input, Output, OutputReference}
 use aiken/transaction/value.{AssetName, PolicyId}
 
 /// Copied from [Fortuna](https://github.com/cardano-miners/fortuna/blob/5eeb1bc31b72252b991bbcaf836b128dca6a74b9/lib/fortuna/utils.ak#L6-L17).
@@ -8,7 +9,6 @@ pub fn resolve_output_reference(
   output_ref: OutputReference,
 ) -> Output {
   expect [input, ..] = inputs
-
 
   if input.output_reference == output_ref {
     input.output


### PR DESCRIPTION
Updated imports to resolve this  unknown type error:

```
 pub fn resolve_output_reference(
 7 │   inputs: List<Input>,
   ·                ──┬──
   ·                  ╰── unknown type
 8 │   output_ref: OutputReference,
 9 │ ) -> Output {
   ╰────
  help: Did you mean 'Int'?

      Summary 1 error, 0 warnings
```