### PR TITLE
Generic Merkelized Validator

### DIFF
--- a/aiken.toml
+++ b/aiken.toml
@@ -1,5 +1,5 @@
 name = "anastasia-labs/aiken-design-patterns"
-version = "1.1.1"
+version = "1.2.0"
 plutus = "v3"
 license = "Apache-2.0"
 description = "Implementations of common design patterns for Cardano smart contracts"

--- a/aiken.toml
+++ b/aiken.toml
@@ -1,5 +1,5 @@
 name = "anastasia-labs/aiken-design-patterns"
-version = "1.1.0"
+version = "1.1.1"
 plutus = "v3"
 license = "Apache-2.0"
 description = "Implementations of common design patterns for Cardano smart contracts"

--- a/lib/aiken-design-patterns/merkelized-validator.ak
+++ b/lib/aiken-design-patterns/merkelized-validator.ak
@@ -98,6 +98,17 @@ pub fn delegated_validation(
   coerced_input == function_input
 }
 
+pub fn generic_delegated_validation(
+  staking_validator: ScriptHash,
+  withdraw_redeemer_validator: fn(Data) -> Bool,
+  redeemers: Pairs<ScriptPurpose, Redeemer>,
+) -> Bool {
+  expect Some(rdmr) =
+    redeemers
+      |> pairs.get_first(Withdraw(Script(staking_validator)))
+  withdraw_redeemer_validator(rdmr)
+}
+
 /// Helper function for defining your "computation stake validator." The
 /// resulting stake validator will carry out the provided `function`'s logic,
 /// and `redeemer` must contain the input(s) and expected output(s).
@@ -186,4 +197,32 @@ test fail_delegated_validation(script_hash via fuzz.bytearray_fixed(28)) fail {
     ),
     withdraw(fn(x: Int) { x == 42 }, redeemer),
   }
+}
+
+test success_generic_delegated_validation(
+  script_hash via fuzz.bytearray_fixed(28),
+) {
+  let redeemer_data: Data = builtin.i_data(42)
+  generic_delegated_validation(
+    script_hash,
+    fn(rdmr: Data) -> Bool {
+      let i = builtin.un_i_data(rdmr)
+      i == 42
+    },
+    [Pair(Withdraw(Script(script_hash)), redeemer_data)],
+  )
+}
+
+test fail_generic_delegated_validation(
+  script_hash via fuzz.bytearray_fixed(28),
+) fail {
+  let redeemer_data: Data = builtin.i_data(42)
+  generic_delegated_validation(
+    script_hash,
+    fn(rdmr: Data) -> Bool {
+      let i = builtin.un_i_data(rdmr)
+      i == 42
+    },
+    [Pair(Withdraw(Script(blake2b_224(script_hash))), redeemer_data)],
+  )
 }


### PR DESCRIPTION
Expose an additional Merkelized validator that doesn't require the withdraw redeemer to be either a `WithdrawRedeemer` or `WithdrawRedeemerIO`.